### PR TITLE
added AccountTest to problem with @Column on Postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,21 +23,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
-      <version>12.1.8</version>
+      <version>12.3.3</version>
     </dependency>
 
     <!-- optionally add query beans -->
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>12.1.8</version>
+      <version>12.3.3</version>
     </dependency>
 
     <!-- java annotation processor to generate query beans -->
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>querybean-generator</artifactId>
-      <version>12.1.8</version>
+      <version>12.3.3</version>
       <scope>provided</scope>
     </dependency>
 
@@ -46,9 +46,17 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>12.1.8</version>
+      <version>12.3.3</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/io.ebean.test/ebean-test-docker -->
+    <dependency>
+      <groupId>io.ebean.test</groupId>
+      <artifactId>ebean-test-docker</artifactId>
+      <version>3.1.5</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.avaje.composite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.8</version>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/org/example/domain/Account.java
+++ b/src/main/java/org/example/domain/Account.java
@@ -1,0 +1,46 @@
+package org.example.domain;
+
+import io.ebean.Model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+public class Account extends Model {
+
+  @Id @Column(name = "ID")
+  Long id;
+
+  String name;
+
+  String notes;
+
+  @Version
+  Long version;
+
+  public Account(String name) {
+    this.name = name;
+  }
+
+  public Account() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/src/test/java/org/example/domain/AccountTest.java
+++ b/src/test/java/org/example/domain/AccountTest.java
@@ -1,0 +1,79 @@
+package org.example.domain;
+
+import io.ebean.DB;
+import io.ebean.Database;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * When running tests in the IDE install the "Enhancement plugin".
+ * <p>
+ * http://ebean-orm.github.io/docs/setup/enhancement#ide
+ */
+public class AccountTest
+{
+
+
+  /**
+   * Get the "default database" and save().
+   */
+  @Test
+  public void insert_via_server() {
+
+    Customer rob = new Customer("Rob");
+
+    Database server = DB.getDefault();
+    server.save(rob);
+
+    assertNotNull(rob.getId());
+  }
+
+  /**
+   * Use the Ebean singleton (effectively using the "default server").
+   */
+  @Test
+  public void insert_via_model() {
+
+    Account jimAccount = new Account("Jim");
+    jimAccount.save();
+
+    assertNotNull(jimAccount.getId());
+  }
+
+
+  /**
+   * Find and then update.
+   */
+  @Test
+  public void updateRob() {
+
+    Account rob = new Account("Rob");
+    rob.save();
+
+    Account bob = DB.find(Account.class)
+      .where().eq("name", "Rob")
+      .findOne();
+
+    bob.setName("newRob");
+    bob.save();
+  }
+
+  /**
+   * Execute an update without a prior query.
+   */
+  @Test
+  public void statelessUpdate() {
+
+    Account newMob = new Account("Mob");
+    newMob.save();
+
+    Account upd = new Account();
+    upd.setId(newMob.getId());
+    upd.setName("Update without a fetch");
+
+    upd.update();
+  }
+
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,7 +1,12 @@
 ebean:
   test:
-#    useDocker: false
+    useDocker: false
 #    shutdown: stop # stop | remove
-    platform: h2 # h2, postgres, mysql, oracle, sqlserver, sqlite
+    platform: postgres # h2, postgres, mysql, oracle, sqlserver, sqlite
     ddlMode: dropCreate # none | dropCreate | create | migration | createOnly | migrationDropCreate
     dbName: myapp
+    postgres:
+      username: postgres
+      password: postgres
+      url: jdbc:postgresql://localhost:5432/
+

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,12 +1,12 @@
 ebean:
   test:
-    useDocker: false
-#    shutdown: stop # stop | remove
+    useDocker: true
+    shutdown: stop # stop | remove
     platform: postgres # h2, postgres, mysql, oracle, sqlserver, sqlite
     ddlMode: dropCreate # none | dropCreate | create | migration | createOnly | migrationDropCreate
     dbName: myapp
     postgres:
       username: postgres
-      password: postgres
-      url: jdbc:postgresql://localhost:5432/
+      password: admin
+      url: jdbc:postgresql://localhost:6432/postgres
 


### PR DESCRIPTION
The AccountTest failed due to `@Column(name="ID")` annotation on the Account entity class with the following error.  It affected postgres only, not oracle and sql server.

```
18:24:13.881 [main] INFO  io.ebean.DDL - Executing db-create-all.sql - 2 statements, autoCommit:false
18:24:13.882 [main] DEBUG io.ebean.DDL - executing 1 of 2 create table account (   id                            bigint generated by defau...
18:24:13.894 [main] DEBUG io.ebean.DDL - executing 2 of 2 create table customer (   id                            bigint generated by defa...
18:24:13.911 [main] DEBUG io.ebean.SQL - txn[1001] insert into account (name, notes, version) values (?,?,?); -- bind(Rob,null,1)
18:24:13.918 [main] DEBUG io.ebean.SUM - txn[1001] Error[ERROR: column "ID" does not exist   Position: 72]
18:24:13.918 [main] TRACE io.ebean.TXN - txn[1001] Commit - query only

javax.persistence.PersistenceException: Error[ERROR: column "ID" does not exist   Position: 72]

	at io.ebean.config.dbplatform.SqlCodeTranslator.translate(SqlCodeTranslator.java:55)
	at io.ebean.config.dbplatform.DatabasePlatform.translate(DatabasePlatform.java:231)
```